### PR TITLE
Austinchappell/fix user link color

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -138,6 +138,9 @@
 
 	.user_menu {
 		border-radius: 50%;
+		display: flex;
+		justify-content: center;
+		align-items: center;
 		--size: 35px;
 		height: var(--size);
 		width: var(--size);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -108,7 +108,7 @@
 	}
 
 	a {
-		color: initial;
+		color: inherit;
 		text-decoration: none;
 	}
 


### PR DESCRIPTION
## The Issue

The username character is difficult to read in dark mode, with the dark font on a dark background

## The Solution

- Update anchor tags to use `inherit` for the `color`
- Center the text inside the anchor tag

## Visuals

### Dark Mode
Before | After
----- | -----
![image](https://github.com/stolinski/svelte-5-drizzle-sveltekit-2-example/assets/20483201/78c0c264-054e-455a-8922-3bc3ebbce168) | ![Screenshot 2024-01-26 at 4 57 01 PM](https://github.com/stolinski/svelte-5-drizzle-sveltekit-2-example/assets/20483201/668008cc-7fba-4210-a5ab-c0d482df201e)

### Light Mode
Before | After
----- | -----
![image](https://github.com/stolinski/svelte-5-drizzle-sveltekit-2-example/assets/20483201/c4e912dc-3bd3-4df1-b4b1-078b53f8ce5f) | ![image](https://github.com/stolinski/svelte-5-drizzle-sveltekit-2-example/assets/20483201/361bfb60-b562-40ad-ad88-a48a8a995a0b)
