### PR TITLE
Add page to update a password

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -42,3 +42,7 @@ export function jump_2_today() {
 export function toggle_values<A, B>(VAL: A | B, VAL_1: A, VAL_2: B): A | B {
 	return VAL === VAL_1 ? VAL_2 : VAL_1;
 }
+
+export function check_is_password_valid(password: string) {
+	return typeof password === 'string' && password.length >= 6 && password.length <= 255;
+}

--- a/src/routes/login/+page.server.ts
+++ b/src/routes/login/+page.server.ts
@@ -3,6 +3,7 @@ import { isValidEmail } from '$lib/server/email';
 
 import type { PageServerLoad, Actions } from './$types';
 import { login_with_password, log_user_in, normalizeEmail } from '$lib/server/auth';
+import { check_is_password_valid } from '$lib/utils';
 
 export const load: PageServerLoad = async ({ locals }) => {
 	if (locals.user) {
@@ -21,7 +22,7 @@ export const actions: Actions = {
 				message: 'Invalid email'
 			});
 		}
-		if (typeof password !== 'string' || password.length < 6 || password.length > 255) {
+		if (!check_is_password_valid(password)) {
 			return fail(400, {
 				message: 'Invalid password'
 			});

--- a/src/routes/signup/+page.server.ts
+++ b/src/routes/signup/+page.server.ts
@@ -6,6 +6,7 @@ import { bcryptPassword, getPasswordString, log_user_in, normalizeEmail } from '
 import { user } from '../../schema';
 import { db } from '../../hooks.server';
 import { PIN } from '$env/static/private';
+import { check_is_password_valid } from '$lib/utils';
 
 export const load: PageServerLoad = async ({ locals }) => {
 	if (locals.user) {
@@ -30,7 +31,7 @@ export const actions: Actions = {
 				message: 'Invalid email',
 			});
 		}
-		if (typeof password !== 'string' || password.length < 6 || password.length > 255) {
+		if (!check_is_password_valid(password)) {
 			return fail(400, {
 				message: 'Invalid password',
 			});

--- a/src/routes/update-password/+page.server.ts
+++ b/src/routes/update-password/+page.server.ts
@@ -1,0 +1,78 @@
+import { fail, redirect } from '@sveltejs/kit';
+import type { Actions } from './$types';
+import { bcryptPassword, getPasswordString, log_user_in, login_with_password, normalizeEmail } from '$lib/server/auth';
+import { db } from '../../hooks.server';
+import { user } from '../../schema';
+import { eq } from 'drizzle-orm';
+import { check_is_password_valid } from '$lib/utils';
+
+export const load = async function ({ locals }) {
+	locals.user;
+};
+
+export const actions: Actions = {
+	default: async ({ locals, cookies }) => {
+		if (!locals.user) {
+			throw redirect(302, '/');
+		}
+
+		const { old_password, new_password, confirm_password } = locals.form_data;
+
+		if (old_password === new_password) {
+			return fail(400, {
+				message: 'New password cannot be the same as the old password',
+			});
+		}
+
+		// basic check
+		if (!check_is_password_valid(new_password)) {
+			return fail(400, {
+				message: 'New password does not meet requirements',
+			});
+		}
+
+		if (new_password !== confirm_password) {
+			return fail(400, {
+				message: 'Passwords do not match',
+			});
+		}
+
+		const successful_login = await login_with_password(old_password, locals.user?.email ?? '' as string);
+
+		if (!successful_login) {
+			return fail(400, {
+				message: 'Old password is incorrect',
+			});
+		}
+
+		try {
+			// Hash password
+			const passwordHash: string = getPasswordString(new_password);
+
+			// Salts the hashed password before saving to the db
+			// Salt Password
+			const passwordBcrypt: string = await bcryptPassword(passwordHash);
+
+			// Create new user
+			const logged_in_user = await db
+				.update(user)
+				.set({
+					hashed_password: passwordBcrypt,
+				})
+				.where(eq(user.id, locals.user?.id ?? 0))
+				.returning();
+
+			// Update the user's session
+			await log_user_in({ user_id: logged_in_user[0].id, cookies });
+		} catch (e) {
+			console.error('e', e);
+			// check for unique constraint error in user table
+			return fail(500, {
+				message: 'An unknown error occurred',
+			});
+		}
+		// redirect to
+		// make sure you don't throw inside a try/catch block!
+		throw redirect(302, '/');
+	},
+};

--- a/src/routes/update-password/+page.svelte
+++ b/src/routes/update-password/+page.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+	const { form } = $props();
+	let loading = $state(false);
+</script>
+
+<h1>Update Password</h1>
+<form
+	class="form"
+	method="post"
+	use:enhance={() => {
+		loading = true;
+		return async ({ update }) => {
+			loading = false;
+			update();
+		};
+	}}
+>
+	<div class="row">
+		<label for="old_password">Old Password</label>
+		<input type="password" name="old_password" id="old_password" /><br />
+	</div>
+	<div class="row">
+		<label for="new_password">New Password</label>
+		<input type="password" name="new_password" id="new_password" /><br />
+	</div>
+	<div class="row">
+		<label for="confirm_password">Confirm New Password</label>
+		<input type="password" name="confirm_password" id="confirm_password" /><br />
+	</div>
+	<button class="button" type="submit" disabled={loading}
+	>{#if loading}Updating password...{:else}
+		Update Password
+	{/if}</button
+	>
+</form>
+{#if form?.message}
+	<p class="error">{form.message}</p>
+{/if}
+<a href="/user">Back to User Settings</a>

--- a/src/routes/user/+page.svelte
+++ b/src/routes/user/+page.svelte
@@ -73,6 +73,8 @@
 		<h1 class="h4">User Settings</h1>
 		<h2 class="h6">{data?.user?.email}</h2>
 
+		<a href="/update-password">Change Password</a>
+
 		<form
 			action="?/logout"
 			use:enhance={() => {


### PR DESCRIPTION
## The Issue

A user does not have a way to change their password. I saw the "reset password workflow" on the roadmap, and thought I would tackle it. It wasn't until I opened this PR that I realized you might be referring to a "forgot password" workflow, which this PR does not do.

## The Solution

- Add an `update-password` page
- Add a util to check password validation to ensure consistency
- Add logic to check for updating a user's password

## To Test

- Navigate to the user settings page
- Click "Change password"
- Update the password
  - It should break if:
    - The old password is incorrect
    - The new password and confirm password do not match
    - The new password is the same as the old password

## Visuals

![after](https://github.com/stolinski/svelte-5-drizzle-sveltekit-2-example/assets/20483201/6e118551-77e4-4240-a2f9-88f484912bfd)

## Known Issue

I'm pretty new to Svelte. I think it makes sense to navigate back to the user settings page after the form submission succeeds, but I am not sure how to do that. @stolinski could probably tackle that part, and I would love to see how to do it.