### PR TITLE
Add check to ensure user does not already exist on sign up

### DIFF
--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -79,7 +79,7 @@ export const bcryptPassword = async (password: string): Promise<string> => {
 };
 
 export const normalizeEmail = (email: string): string => {
-	return decodeURIComponent(email).toLowerCase();
+	return decodeURIComponent(email).toLowerCase().trim();
 };
 
 // Compares password to hash to confirm they are the same

--- a/src/routes/signup/+page.server.ts
+++ b/src/routes/signup/+page.server.ts
@@ -1,5 +1,7 @@
 import { fail, redirect } from '@sveltejs/kit';
 import { isValidEmail } from '$lib/server/email';
+import { PIN } from '$env/static/private';
+import { eq } from 'drizzle-orm';
 
 import type { PageServerLoad, Actions } from './$types';
 import { bcryptPassword, getPasswordString, log_user_in, normalizeEmail } from '$lib/server/auth';

--- a/src/routes/signup/+page.server.ts
+++ b/src/routes/signup/+page.server.ts
@@ -7,6 +7,7 @@ import { user } from '../../schema';
 import { db } from '../../hooks.server';
 import { PIN } from '$env/static/private';
 import { check_is_password_valid } from '$lib/utils';
+import { eq } from 'drizzle-orm';
 
 export const load: PageServerLoad = async ({ locals }) => {
 	if (locals.user) {
@@ -37,6 +38,18 @@ export const actions: Actions = {
 			});
 		}
 		try {
+			// Check if user exists
+			const user_exists = await db
+				.query
+				.user
+				.findFirst({ where: eq(user.email, normalized_email) });
+
+			if (user_exists) {
+				return fail(400, {
+					message: 'User already exists',
+				});
+			}
+
 			// Hash password
 			const passwordHash: string = getPasswordString(password);
 


### PR DESCRIPTION
## The Issue

Multiple users can sign up with the same email address

## The Solution

Add a check on signup to ensure that no user already exists with the email provided

## To Test

- Create a user account
- Attempt to create a second user with the same email address
  - Even if you add spaces at the end, it should not succeed

## Visuals

<img width="1341" alt="image" src="https://github.com/stolinski/svelte-5-drizzle-sveltekit-2-example/assets/20483201/a0e6961f-aaa3-43e3-a68f-b17daa618d78">

## Future Work

There should probably be a unique constraint on the `email` column in the `users` table. It's best to have this level of data validation as low as possible. I did not add it here, as I don't know if there are unique users already in production. If there are duplicates in prod, the migration to add the unique constraint will fail.