### PR TITLE
Fix date parsing issue for first of month

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,4 @@
-import { eachDayOfInterval, endOfMonth, startOfMonth } from 'date-fns';
+import { eachDayOfInterval, endOfMonth, format, startOfMonth } from 'date-fns';
 
 export const get_circular_array_item = (array: string[], index: number) => {
 	// Ensure the index is a positive number then get the modulus with the array length
@@ -45,4 +45,21 @@ export function toggle_values<A, B>(VAL: A | B, VAL_1: A, VAL_2: B): A | B {
 
 export function check_is_password_valid(password: string) {
 	return typeof password === 'string' && password.length >= 6 && password.length <= 255;
+}
+
+// incoming date format: 2024-01-01
+export function parse_date(date: string): [year: number, month: number, day: number] {
+	const [year, month, day] = date.split('-').map(Number);
+
+	// it's fine if month returns a negative number
+	// new Date(2024, -1, 1) will return new Date(2023, 11, 1)
+	return [year, month - 1, day]; // month is 0 indexed
+}
+
+export function get_param_date(date: Date) {
+	return format(date, 'yyyy-MM-dd');
+}
+
+export function date_without_timezone(date: Date): Date {
+	return new Date(date.valueOf() + date.getTimezoneOffset() * 60 * 1000);
 }

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -4,12 +4,14 @@ import { db } from '../hooks.server';
 import { checks, habits } from '../schema';
 import { transform_habits, update_habits_order } from '../server/data_utils';
 import { fail } from '@sveltejs/kit';
+import { date_without_timezone, get_param_date, parse_date } from '$lib/utils';
 
 export const load = async ({ locals, url }) => {
-	const date = url.searchParams.get('date') || format(new Date(), 'yyyy-MM-dd');
+	const date = url.searchParams.get('date') || get_param_date(date_without_timezone(new Date()));
+	const parsed_date = parse_date(date);
 	// Get first day of month and last day of month in 2024-01-01 format
-	const firstDayOfMonth = format(startOfMonth(new Date(date)), 'yyyy-MM-dd');
-	const lastDayOfMonth = format(endOfMonth(new Date(date)), 'yyyy-MM-dd');
+	const firstDayOfMonth = get_param_date(startOfMonth(new Date(...parsed_date)));
+	const lastDayOfMonth = get_param_date(endOfMonth(new Date(...parsed_date)));
 
 	//  Add check for proper month between.
 	const habits_data = await db.query.habits.findMany({

--- a/src/routes/HabitRow.svelte
+++ b/src/routes/HabitRow.svelte
@@ -2,7 +2,7 @@
 	import DropMenu from '$lib/DropMenu.svelte';
 	import { COLORS, DARK_COLORS } from '$lib/const';
 	import { app } from '$lib/state.svelte';
-	import { get_circular_array_item } from '$lib/utils.js';
+	import { date_without_timezone, get_circular_array_item } from '$lib/utils.js';
 	import { fade } from 'svelte/transition';
 
 	import { format } from 'date-fns';
@@ -10,7 +10,7 @@
 	import DailyButton from './DailyButton.svelte';
 	import type { ActionData } from '../../.svelte-kit/types/src/routes/$types';
 
-	let right_now = new Date();
+	let right_now = date_without_timezone(new Date());
 	const today = format(
 		new Date(Date.UTC(right_now.getUTCFullYear(), right_now.getUTCMonth(), right_now.getUTCDate())),
 		'yyyy-MM-dd',

--- a/src/state/date.svelte.ts
+++ b/src/state/date.svelte.ts
@@ -1,17 +1,22 @@
 import { goto } from '$app/navigation';
-import { format } from 'date-fns';
+import { date_without_timezone, get_param_date } from '$lib/utils';
+
+function change_month(active_date: Date, delta: number) {
+	const new_active_date = date_without_timezone(new Date(active_date));
+	new_active_date.setMonth(active_date.getMonth() + delta);
+
+	const new_data_params = get_param_date(new_active_date);
+
+	const new_params = new URLSearchParams();
+	new_params.set('date', new_data_params);
+
+	goto(`?${new_params.toString()}`, { replaceState: true });
+}
 
 export function next_month(active_date: Date) {
-	const newParams = new URLSearchParams();
-	let new_active_date = new Date(active_date.setMonth(active_date.getMonth() + 1));
-	newParams.set('date', format(new_active_date, 'yyyy-MM-dd'));
-	goto(`?${newParams.toString()}`, { replaceState: true });
+	change_month(active_date, 1);
 }
 
 export function prev_month(active_date: Date) {
-	const newParams = new URLSearchParams();
-	let new_active_date = new Date(active_date.setMonth(active_date.getMonth() - 1));
-
-	newParams.set('date', format(new_active_date, 'yyyy-MM-dd'));
-	goto(`?${newParams.toString()}`, { replaceState: true });
+	change_month(active_date, -1);
 }

--- a/src/state/date.svelte.ts
+++ b/src/state/date.svelte.ts
@@ -13,10 +13,10 @@ function change_month(active_date: Date, delta: number) {
 	goto(`?${new_params.toString()}`, { replaceState: true });
 }
 
-export function next_month(active_date: Date) {
-	change_month(active_date, 1);
+export function next_month(date: Date) {
+	change_month(date, 1);
 }
 
-export function prev_month(active_date: Date) {
-	change_month(active_date, -1);
+export function prev_month(date: Date) {
+	change_month(date, -1);
 }


### PR DESCRIPTION
After opening this PR, I'm continually less confident this is the right solution. I might come back to tweak this tomorrow. 

## The Issue

When loading the app on the first day of the month, we encounter issues with navigating between previous and next months due to timezone discrepencies. As shown in the "before" gif, the page navigated straight from February to December. 

## The Solution

Caveat: I'm not sure if this will work perfectly, since some of these timezones will be calculated on the server side. Maybe something like a cookie in the user's browser communicating their timezone offset would be useful. Not sure.

- Add a couple of utils
  - One to parse a date and return a `[year, month, day]` tuple
  - Another to format the param date of `yyyy-MM-dd` to ensure consistency throughout the app
- Refactor the `next_month` and `previous_month` helpers to share code and make debugging easier

## Visuals

### Before

- Also watch the "day" value in the URL. It is decrementing by 1 each time the month changes.

![before](https://github.com/stolinski/svelte-5-drizzle-sveltekit-2-example/assets/20483201/65aece55-1128-4ea0-873e-311ab7814d94)

### After

![after](https://github.com/stolinski/svelte-5-drizzle-sveltekit-2-example/assets/20483201/026ef9e9-b105-47bc-a91b-13f368b510b5)
